### PR TITLE
Use symbolic links instead of hard links

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function installArchSpecificPackage(version, require) {
       }
     }
 
-    linkSync(bin, path.resolve(process.cwd(), executable));
+    symlinkSync(bin, path.resolve(process.cwd(), executable));
 
     if (platform == 'win') {
       var pkg = JSON.parse(fs.readFileSync(path.resolve(process.cwd(), 'package.json')));
@@ -42,7 +42,7 @@ function installArchSpecificPackage(version, require) {
   });
 }
 
-function linkSync(src, dest) {
+function symlinkSync(src, dest) {
   try {
     fs.unlinkSync(dest);
   } catch (e) {
@@ -50,7 +50,7 @@ function linkSync(src, dest) {
       throw e;
     }
   }
-  return fs.linkSync(src, dest);
+  return fs.symlinkSync(src, dest);
 }
 
 module.exports = installArchSpecificPackage;


### PR DESCRIPTION
This specifically fixes an issue with creating hard links in a synced folder in a Vagrant VM, as well as potential issues with linking to files without specific permissions/ownership.