### PR TITLE
Fix armv7l install by using `arch'

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var spawn = require('child_process').spawn;
+var { spawn, execSync } = require('child_process')
 var path = require('path');
 var fs = require('fs');
 
@@ -8,6 +8,14 @@ function installArchSpecificPackage(version, require) {
 
   var platform = process.platform == 'win32' ? 'win' : process.platform;
   var arch = platform == 'win' && process.arch == 'ia32' ? 'x86' : process.arch;
+
+  if (arch === 'arm') {
+    var armCpu = execSync('arch')
+
+    if (typeof armCpu !== 'undefined' && armCpu.toString().trim().length > 0) {
+      arch = armCpu.toString().trim()
+    }
+  }
 
   var cp = spawn(platform == 'win' ? 'npm.cmd' : 'npm', ['install', '--no-save', ['node', platform, arch].join('-') + '@' + version], {
     stdio: 'inherit',


### PR DESCRIPTION
Supercedes https://github.com/aredridel/node-bin-gen/pull/58 (see [this comment](https://github.com/aredridel/node-bin-gen/pull/58#discussion_r247939323)). 

@aredridel: I wasn't able to confirm that this works (or doesn't work) using [the steps you mentioned in this comment](https://github.com/aredridel/node-bin-gen/pull/58#issuecomment-454433034). I'm a bit confused about which packages I should install from npm, which I should install locally, and what my initial test project should look like. Is `npm init -y` okay? Or should I use [the failing example project](https://gitlab.com/josh-bitovi/project-local-node--npm-install-issue/) I made when reporting this?

> Background: https://github.com/aredridel/node-bin-gen/issues/57 