### PR TITLE
Fix installation of node-linux-ppc64le

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function installArchSpecificPackage(version, require) {
   process.env.npm_config_global = 'false';
 
   var platform = process.platform == 'win32' ? 'win' : process.platform;
-  var arch = platform == 'win' && process.arch == 'ia32' ? 'x86' : process.arch;
+  var arch = platform == 'win' && process.arch == 'ia32' ? 'x86' : process.arch == 'ppc64' && process.config.variables.node_byteorder == 'little' ? 'ppc64le' : process.arch;
   var prefix = (process.platform == 'darwin' && process.arch == 'arm64') ? 'node-bin' : 'node';
 
   var cp = spawn(platform == 'win' ? 'npm.cmd' : 'npm', ['install', '--no-save', [prefix, platform, arch].join('-') + '@' + version], {


### PR DESCRIPTION
Node.js defines process.arch as ppc64 for both obsolete BE and current LE systems, however these are not compatible with each other.  However, ppc64 BE builds of Node.js have ceased since version 8, and only node-linux-ppc64le is currently available.  This currently results in:

```
$ npm install node
npm ERR! npm ERR! code ETARGET
npm ERR! npm ERR! notarget No matching version found for node-linux-ppc64@19.1.0.
npm ERR! npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! npm ERR! notarget a package version that doesn't exist.
```

A combination of this and https://github.com/aredridel/node-bin-gen/pull/186 is needed to fix `npm install node` on Power LE.