### PR TITLE
Fix installation with npm11 and private repository setup

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var fs = require('fs');
 function installArchSpecificPackage(version, require) {
 
   process.env.npm_config_global = 'false';
+  process.env.npm_config_repository = '';
 
   var platform = process.platform == 'win32' ? 'win' : process.platform;
   var arch = platform == 'win' && process.arch == 'ia32' ? 'x86' : process.arch;


### PR DESCRIPTION
It does reset the inherited environment configuration and does read it again
from the filesystem when npm is started in the spawned shell.

Fixes https://github.com/aredridel/node-bin-gen/issues/60#issuecomment-2871823256
